### PR TITLE
Update pp.py

### DIFF
--- a/superslicer/pp.py
+++ b/superslicer/pp.py
@@ -74,7 +74,7 @@ try:
 				#orgline = line
 				for i in range(0,len(items)):
 					if items[i].startswith('E'):
-						items[i] = 'E' + str( round( float( items[i][1:] ) * extr_mult, 6 ))
+						items[i] = 'E' + '{:f}'.format( float( items[i][1:] ) * extr_mult)
 					line = ' '.join(items) + "\n"# + ' ; mult ' + str(extr_mult)
 				#import pdb; pdb.set_trace()
 


### PR DESCRIPTION
This code prevents gcode being generated that contains scientific notation like "1e-6" that is interpreted as 6mm retraction, then setting other values of flow in 'more_extrusions'